### PR TITLE
feat: make dynamodb table optional for AWS state-file

### DIFF
--- a/terraform-modules/aws/state-file/README.md
+++ b/terraform-modules/aws/state-file/README.md
@@ -28,6 +28,7 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_create_dynamodb_table"></a> [create\_dynamodb\_table](#input\_create\_dynamodb\_table) | Whether to create the DynamoDB table used for Terraform state locking. | `bool` | `true` | no |
 | <a name="input_iam_principals"></a> [iam\_principals](#input\_iam\_principals) | A list of IAM user or role ARNs that will have access to the state S3 bucket | `list(string)` | n/a | yes |
 | <a name="input_region_name"></a> [region\_name](#input\_region\_name) | Name of the region that the state file is responsible for | `string` | n/a | yes |
 | <a name="input_state_bucket_kms_key_id"></a> [state\_bucket\_kms\_key\_id](#input\_state\_bucket\_kms\_key\_id) | The KMS key ID used to encrypt the S3 state bucket. Uses AWS-managed key if not specified. | `string` | `""` | no |
@@ -36,8 +37,8 @@ No requirements.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_dynamodb_table_arn"></a> [dynamodb\_table\_arn](#output\_dynamodb\_table\_arn) | The ARN of the DynamoDB table |
-| <a name="output_dynamodb_table_name"></a> [dynamodb\_table\_name](#output\_dynamodb\_table\_name) | The name of the DynamoDB table |
+| <a name="output_dynamodb_table_arn"></a> [dynamodb\_table\_arn](#output\_dynamodb\_table\_arn) | The ARN of the DynamoDB table (null when create\_dynamodb\_table is false) |
+| <a name="output_dynamodb_table_name"></a> [dynamodb\_table\_name](#output\_dynamodb\_table\_name) | The name of the DynamoDB table (null when create\_dynamodb\_table is false) |
 | <a name="output_s3_logging_bucket_arn"></a> [s3\_logging\_bucket\_arn](#output\_s3\_logging\_bucket\_arn) | The ARN of the S3 logging bucket |
 | <a name="output_s3_state_bucket_arn"></a> [s3\_state\_bucket\_arn](#output\_s3\_state\_bucket\_arn) | The ARN of the S3 state bucket |
 | <a name="output_s3_state_bucket_id"></a> [s3\_state\_bucket\_id](#output\_s3\_state\_bucket\_id) | The ID of the S3 state bucket |

--- a/terraform-modules/aws/state-file/README.md
+++ b/terraform-modules/aws/state-file/README.md
@@ -23,6 +23,7 @@ No requirements.
 | [aws_dynamodb_table.terraform_locks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.terraform_state_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_session_context.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_session_context) | data source |
 
 ## Inputs
 

--- a/terraform-modules/aws/state-file/USAGE.MD
+++ b/terraform-modules/aws/state-file/USAGE.MD
@@ -1,14 +1,15 @@
 # Bootstrapping AWS accounts for Terraform backend
 
-This Terraform module bootstraps an AWS account by creating an S3 bucket and a DynamoDB table, which are essential components for storing remote Terraform state files. Access to the S3 bucket is restricted to IAM users and roles passed in as `iam_principals` input variable list.
+This Terraform module bootstraps an AWS account by creating an S3 bucket and, by default, a DynamoDB table for state locking. Access to the S3 bucket is restricted to IAM users and roles passed in as `iam_principals` input variable list.
 
 ## Usage
 
 ```hcl
 module "bootstrap" {
   source = "./"
-  region               = "eu-west-1"
-  iam_principals       = ["arn:aws:iam::123456789012:user/example-user"]
+  region                = "eu-west-1"
+  iam_principals        = ["arn:aws:iam::123456789012:user/example-user"]
+  create_dynamodb_table = false
 }
 ```
 
@@ -65,3 +66,5 @@ terraform init \
   -backend-config=key=s3-backend-state/terraform.tfstate \
   -force-copy
 ```
+
+If you set `create_dynamodb_table = false`, skip the `dynamodb_table` backend config and use only the S3 backend.

--- a/terraform-modules/aws/state-file/main.tf
+++ b/terraform-modules/aws/state-file/main.tf
@@ -115,6 +115,7 @@ module "terraform_state_log" {
 resource "aws_dynamodb_table" "terraform_locks" {
   # checkov:skip=CKV_AWS_28:The state lock table is ephemeral and doesn't need PITR.
   # checkov:skip=CKV_AWS_119:No data is contained in this table. Encrypting with CMK is unnecessary.
+  count        = var.create_dynamodb_table ? 1 : 0
   name         = "${var.region_name}-state-locks"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "LockID"

--- a/terraform-modules/aws/state-file/outputs.tf
+++ b/terraform-modules/aws/state-file/outputs.tf
@@ -14,11 +14,11 @@ output "s3_logging_bucket_arn" {
 }
 
 output "dynamodb_table_arn" {
-  value       = aws_dynamodb_table.terraform_locks.arn
-  description = "The ARN of the DynamoDB table"
+  value       = var.create_dynamodb_table ? aws_dynamodb_table.terraform_locks[0].arn : null
+  description = "The ARN of the DynamoDB table (null when create_dynamodb_table is false)"
 }
 
 output "dynamodb_table_name" {
-  value       = aws_dynamodb_table.terraform_locks.name
-  description = "The name of the DynamoDB table"
+  value       = var.create_dynamodb_table ? aws_dynamodb_table.terraform_locks[0].name : null
+  description = "The name of the DynamoDB table (null when create_dynamodb_table is false)"
 }

--- a/terraform-modules/aws/state-file/variables.tf
+++ b/terraform-modules/aws/state-file/variables.tf
@@ -10,6 +10,12 @@ variable "state_bucket_kms_key_id" {
   default     = ""
 }
 
+variable "create_dynamodb_table" {
+  description = "Whether to create the DynamoDB table used for Terraform state locking."
+  type        = bool
+  default     = true
+}
+
 variable "region_name" {
   description = "Name of the region that the state file is responsible for"
   type        = string


### PR DESCRIPTION
Add an option to disable creating DynamoDB table for AWS state file module